### PR TITLE
Breaking change: unified API

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: go
 go:
-  - 1.5
+  - 1.6
   - tip
 sudo: false

--- a/interface.go
+++ b/interface.go
@@ -1,0 +1,83 @@
+package strcursor
+
+import (
+	"bytes"
+	"io"
+)
+
+type Cursor interface {
+	// Advance moves the position by the requested count of runes.
+	Advance(int) error
+
+	// Column returns the current column number
+	Column() int
+
+	Consume([]byte) bool
+
+	// ConsumeString advances the cursor position by the length of the
+	// input string, only if the input string appears as the next set of
+	// data in the cursor. It returns true if the string was found
+	ConsumeString(string) bool
+
+	// Cur returns the current rune and consumes the rune (calls
+	// Advance()). On error, it returns utf8.RuneError
+	Cur() rune
+
+	// Done returns true if we have exhausted this cursor
+	Done() bool
+
+	// HasPrefix checks if the cursor has the specified set of bytes as prefix
+	HasPrefix([]byte) bool
+
+	// HasPrefix checks if the cursor has the specified string as prefix
+	HasPrefixString(string) bool
+
+	// Line returns the current line that we are processing
+	Line() string
+
+	// LineNumber returns the current line number
+	LineNumber() int
+
+	// Peek returns the current rune, but does not advance the position
+	// On error, it returns utf8.RuneError
+	Peek() rune
+
+	// PeekN returns the rune at requested position.
+	// It does not advance the position.
+	// On error, it returns utf8.RuneError
+	PeekN(int) rune
+}
+
+// ByteCursor is a cursor for consumers that are interested in series of
+// bytes
+type ByteCursor struct {
+	buf    []byte       // scratch bufer, read in from the io.Reader
+	buflen int          // size of scratch buffer
+	bufpos int          // amount consumed within the scratch buffer
+	column int          // column number
+	in     io.Reader    // input source
+	line   bytes.Buffer // current line
+	lineno int          // line number
+}
+
+// RuneCursor is a cursor for consumers that are interested in series of
+// runes (not bytes)
+type RuneCursor struct {
+	buf       []byte       // scratch bufer, read in from the io.Reader
+	buflen    int          // size of scratch buffer
+	bufpos    int          // amount consumed within the scratch buffer
+	column    int          // column number
+	in        io.Reader    // input source
+	line      bytes.Buffer // current line
+	lineno    int          // line number
+	nread     int          // number of bytes consumed so far
+	rabuf     *runebuf     // Read-ahead buffer.
+	lastrabuf *runebuf     // the end of read-ahead buffer.
+	rabuflen  int          // Number of runes in read-ahead buffer
+}
+
+type runebuf struct {
+	val   rune
+	width int
+	next  *runebuf
+}

--- a/rune.go
+++ b/rune.go
@@ -8,28 +8,6 @@ import (
 	"unicode/utf8"
 )
 
-// RuneCursor is a cursor for consumers that are interested in series of
-// runes (not bytes)
-type RuneCursor struct {
-	buf       []byte    // scratch bufer, read in from the io.Reader
-	buflen    int       // size of scratch buffer
-	bufpos    int       // amount consumed within the scratch buffer
-	column    int       // column number
-	in        io.Reader // input source
-	line      bytes.Buffer
-	lineno    int      // line number
-	nread     int      // number of bytes consumed so far
-	rabuf     *runebuf // Read-ahead buffer.
-	lastrabuf *runebuf // the end of read-ahead buffer.
-	rabuflen  int      // Number of runes in read-ahead buffer
-}
-
-type runebuf struct {
-	val   rune
-	width int
-	next  *runebuf
-}
-
 // NewRuneCursor creates a cursor that deals exclusively with runes
 func NewRuneCursor(in io.Reader, nn ...int) *RuneCursor {
 	var n int
@@ -269,16 +247,24 @@ func (c *RuneCursor) hasPrefix(s string, n int, consume bool) bool {
 	return false
 }
 
-// HasPrefix takes a string returns true if the rune buffer contains
+func (c *RuneCursor) HasPrefix(b []byte) bool {
+	return c.HasPrefixString(string(b))
+}
+
+// HasPrefixString takes a string returns true if the rune buffer contains
 // the exact sequence of runes. This method does NOT consume upon a match
-func (c *RuneCursor) HasPrefix(s string) bool {
+func (c *RuneCursor) HasPrefixString(s string) bool {
 	n := utf8.RuneCountInString(s)
 	return c.hasPrefix(s, n, false)
 }
 
+func (c *RuneCursor) Consume(b []byte) bool {
+	return c.ConsumeString(string(b))
+}
+
 // Consume takes a string and advances the cursor that many runes
 // if the rune buffer contains the exact sequence of runes
-func (c *RuneCursor) Consume(s string) bool {
+func (c *RuneCursor) ConsumeString(s string) bool {
 	n := utf8.RuneCountInString(s)
 	return c.hasPrefix(s, n, true)
 }

--- a/rune_test.go
+++ b/rune_test.go
@@ -15,7 +15,8 @@ func TestRuneCursorBasic(t *testing.T) {
 		buf.WriteString(`はろ〜、World!`)
 	}
 	rdr := bytes.NewReader(buf.Bytes())
-	cur := NewRuneCursor(rdr)
+	var cur Cursor
+	cur = NewRuneCursor(rdr)
 
 	{
 		r := cur.PeekN(5)
@@ -55,11 +56,11 @@ func TestRuneCursorConsume(t *testing.T) {
 	rdr := strings.NewReader(`はろ〜、World!`)
 	cur := NewRuneCursor(rdr)
 
-	if !assert.True(t, cur.HasPrefix(`はろ〜`), "cur.HasPrefix() succeeds") {
+	if !assert.True(t, cur.HasPrefixString(`はろ〜`), "cur.HasPrefixString() succeeds") {
 		return
 	}
 
-	if !assert.True(t, cur.Consume(`はろ〜`), "cur.Consume() succeeds") {
+	if !assert.True(t, cur.ConsumeString(`はろ〜`), "cur.ConsumeString() succeeds") {
 		return
 	}
 
@@ -71,7 +72,7 @@ func TestRuneCursorConsume(t *testing.T) {
 		return
 	}
 
-	if !assert.False(t, cur.HasPrefix(`はろ〜`), "cur.HasPrefix() fails") {
+	if !assert.False(t, cur.HasPrefixString(`はろ〜`), "cur.HasPrefixString() fails") {
 		return
 	}
 }
@@ -89,13 +90,13 @@ Charlie`)
 		return
 	}
 
-	if !assert.True(t, cur.Consume("Al"), "cur.Consume() succeeds") {
+	if !assert.True(t, cur.ConsumeString("Al"), "cur.Consume() succeeds") {
 		return
 	}
 	if !assert.Equal(t, 3, cur.Column(), "cur.Column() is 3") {
 		return
 	}
-	if !assert.True(t, cur.Consume("ice\n"), "cur.Consume() succeeds") {
+	if !assert.True(t, cur.ConsumeString("ice\n"), "cur.Consume() succeeds") {
 		return
 	}
 


### PR DESCRIPTION
This change introduces a Cursor interface, which ByteCursor and
RuneCursor both satisfy. This makes things considerably easier for the
end user by allowing them to just use the Cursor type, and not have to
go back and forth between bytes and runes.